### PR TITLE
Go back to amweekly command for now

### DIFF
--- a/amweekly/signals.py
+++ b/amweekly/signals.py
@@ -7,7 +7,7 @@ from amweekly.slack.models import SlashCommand
 
 @receiver(post_save, sender=SlashCommand, dispatch_uid='amweekly_slash_command')  # noqa
 def amweekly_slash_command(sender, instance, **kwargs):
-    if instance.command == '/djangoamweekly':
+    if instance.command == '/amweekly':
         Share.objects.create(
             user_name=instance.user_name,
             url=instance.text)

--- a/amweekly/tests/test_management.py
+++ b/amweekly/tests/test_management.py
@@ -17,5 +17,7 @@ def test_postlinks_command_friday(share, mocker):
 @pytest.mark.django_db
 def test_postlinks_command_not_friday(share, mocker):
     mocked = mocker.patch('amweekly.slack.jobs.process_incoming_webhook.delay')
+    mocked_dt = mocker.patch('amweekly.management.commands.postlinks.datetime.datetime')  # noqa
+    mocked_dt.utcnow.return_value = datetime(2017, 6, 22)  # NOT FRIDAY
     call_command('postlinks')
     assert not mocked.called


### PR DESCRIPTION
It's the only place this was hardcoded (and the way it's currently configured), so go back to the amweekly command until multiple commands are supported.